### PR TITLE
Added GitHub to OpCrux

### DIFF
--- a/_hosted/OPCRUX.md
+++ b/_hosted/OPCRUX.md
@@ -4,6 +4,6 @@ status: Active Development
 language: C++
 accepting_devs: "Yes"
 image_path: /assets/opcrux_logo.png
-links: [['Website', 'https://opcrux.org', 'fas fa-external-link-alt'], ['Twitter', 'https://twitter.com/opcrux', 'fab fa-twitter'], ['Discord', 'https://discord.opcrux.org/', 'fab fa-discord'], ['Youtube', 'https://www.youtube.com/channel/UC5-Z2o03q0_HAz-2ntuOfDA', 'fab fa-youtube']]
+links: [['Website', 'https://opcrux.org', 'fas fa-external-link-alt'], ['Twitter', 'https://twitter.com/opcrux', 'fab fa-twitter'], ['Discord', 'https://discord.opcrux.org/', 'fab fa-discord'], ['Youtube', 'https://www.youtube.com/channel/UC5-Z2o03q0_HAz-2ntuOfDA', 'fab fa-youtube'], ['GitHub', 'https://github.com/SimonNitzsche/OpCrux-Server', 'fab fa-github']]
 devs: Simon, Encry
 ---


### PR DESCRIPTION
Even tho OpCrux is now open source, it will still be hosted.