### PR TITLE
Clarify that assembly is written in Rust going forward

### DIFF
--- a/_devresources/assembly.md
+++ b/_devresources/assembly.md
@@ -1,9 +1,9 @@
 ---
 name: Assembly
 status: Active Development
-language: C/C++
+language: Rust
 tag: General
 desc: LU Server Common Library
-links: [['GitHub', 'https://github.com/Xiphoseer/Assembly', 'fab fa-github']]
+links: [['GitHub', 'https://github.com/Xiphoseer/assembly_rs', 'fab fa-github'], ['docs.rs', 'https://docs.rs/assembly', 'fab fa-rust']]
 author: Xiphoseer
 ---


### PR DESCRIPTION
This updates the assembly link to point to the current repo