### PR TITLE
Some updates

### DIFF
--- a/_hosted/DLU.md
+++ b/_hosted/DLU.md
@@ -1,9 +1,9 @@
 ---
 name: Darkflame Universe (DLU)
-status: Alpha 2
+status: Alpha 2 (Crash Testing)
 language: C++
 accepting_devs: "No"
 image_path: /assets/dlu_logo.png
 links: [['Website','https://www.darkflameuniverse.org/', 'fas fa-external-link-alt'], ['Twitter', 'https://twitter.com/darkflameuniv', 'fab fa-twitter']]
-devs: DarwinAnim8or, Averysumner, Wincent01, lcdr, Neal, Jonny, Bricknave
+devs: DarwinAnim8or, Averysumner, Wincent01, lcdr, Neal, Jonny, Bricknave, Mick Vermeulen, Aronwk (web dev)
 ---

--- a/_hosted/OPCRUX.md
+++ b/_hosted/OPCRUX.md
@@ -1,9 +1,9 @@
 ---
 name: Operation Crux (OpCrux)
-status: Closed Alpha
+status: Open temporarily before it is retired as a hosted project by Simon.
 language: C++
 accepting_devs: "Yes"
 image_path: /assets/opcrux_logo.png
 links: [['Website', 'https://opcrux.org', 'fas fa-external-link-alt'], ['Twitter', 'https://twitter.com/opcrux', 'fab fa-twitter'], ['Discord', 'https://discord.opcrux.org/', 'fab fa-discord'], ['Youtube', 'https://www.youtube.com/channel/UC5-Z2o03q0_HAz-2ntuOfDA', 'fab fa-youtube'], ['GitHub', 'https://github.com/SimonNitzsche/OpCrux-Server', 'fab fa-github']]
-devs: Simon Nitzsche, Encry, RaizCookie
+devs: Simon Nitzsche (hosting only), RaizCookie
 ---

--- a/index.html
+++ b/index.html
@@ -129,7 +129,7 @@ title: LU Server Projects
                 (either via the original
                 <a href="https://docs.google.com/document/d/1v9GB1gNwO0C81Rhd4imbaLN7z-R0zpK5sYJMbxPP3Kc/">Google Docs</a> or the
                 <a href="http://lu-docs.readthedocs.io/en/latest/">Unofficial ReadTheDocs port</a>). Contributions to the documentation of any kind (through additional client or network reverse engineering, systems documentation, typo fixes, or anything else) are also helpful and are always appreciated.
-                If you become comfortable with how LU servers operate and show competance in your development skills, more established projects may also be willing to take you on at that time (generally by invitation). You can also fork this project <a href="lusprojects.github.io">on GitHub</a> and submit a pull request if you wish to improve its content or functionality. </p>
+                If you become comfortable with how LU servers operate and show competance in your development skills, more established projects may also be willing to take you on at that time (generally by invitation). You can also fork this project <a href="github.com/lusprojects/lusprojects.github.io">on GitHub</a> and submit a pull request if you wish to improve its content or functionality. </p>
             <p> Otherwise, your kind words and encouragement do wonders to keep all the developers encouraged to keep working at their hardest to bring back the game as close as possible to the original experience. </p>
         </div>
     </div>


### PR DESCRIPTION
DLU dev list (and status), OpCrux dev list (removed Encry, clarified Simon's role at the moment) and status, set the link to the repo for those who want to update it to link to the GitHub page, rather than just back to the page itself.